### PR TITLE
Fix button layout under product images

### DIFF
--- a/style.css
+++ b/style.css
@@ -179,8 +179,15 @@ header nav a.login-btn:hover {
 }
 
 .produto img {
-  max-width: 100%;
-  height: auto;
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
   margin-bottom: 10px;
   border-radius: 8px;
+}
+
+.produto a.btn {
+  display: block;
+  width: 100%;
+  margin-top: 10px;
 }


### PR DESCRIPTION
## Summary
- update `.produto` styles so the signup button appears below each product image
- crop product images to a fixed height with `object-fit: cover`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6851736b5bf483218439c5495bc064d0