### PR TITLE
Remove Blend Kickboxing courses

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,18 +41,6 @@
       <a href="register.html?curso=Jeet%20Kune%20Do%20-%20Avan%C3%A7ado" class="btn btn-warning cadastro-link">Inscreva-se agora!</a>
     </div>
     <div class="produto">
-      <h3>Blend Kickboxing - Básico</h3>
-      <a href="register.html?curso=Blend%20Kickboxing%20-%20B%C3%A1sico" class="btn btn-warning cadastro-link">Inscreva-se agora!</a>
-    </div>
-    <div class="produto">
-      <h3>Blend Kickboxing - Intermediário</h3>
-      <a href="register.html?curso=Blend%20Kickboxing%20-%20Intermedi%C3%A1rio" class="btn btn-warning cadastro-link">Inscreva-se agora!</a>
-    </div>
-    <div class="produto">
-      <h3>Blend Kickboxing - Avançado</h3>
-      <a href="register.html?curso=Blend%20Kickboxing%20-%20Avan%C3%A7ado" class="btn btn-warning cadastro-link">Inscreva-se agora!</a>
-    </div>
-    <div class="produto">
       <h3>Luta Livre - Básico</h3>
       <a href="register.html?curso=Luta%20Livre%20-%20B%C3%A1sico" class="btn btn-warning cadastro-link">Inscreva-se agora!</a>
     </div>

--- a/register.html
+++ b/register.html
@@ -33,9 +33,6 @@
         <option value="Jeet Kune Do - Básico">Jeet Kune Do - Básico</option>
         <option value="Jeet Kune Do - Intermediário">Jeet Kune Do - Intermediário</option>
         <option value="Jeet Kune Do - Avançado">Jeet Kune Do - Avançado</option>
-        <option value="Blend Kickboxing - Básico">Blend Kickboxing - Básico</option>
-        <option value="Blend Kickboxing - Intermediário">Blend Kickboxing - Intermediário</option>
-        <option value="Blend Kickboxing - Avançado">Blend Kickboxing - Avançado</option>
         <option value="Luta Livre - Básico">Luta Livre - Básico</option>
         <option value="Luta Livre - Intermediário">Luta Livre - Intermediário</option>
         <option value="Luta Livre - Avançado">Luta Livre - Avançado</option>
@@ -57,9 +54,6 @@ const prices = {
   'Jeet Kune Do - Básico': 'R$170',
   'Jeet Kune Do - Intermediário': 'R$190',
   'Jeet Kune Do - Avançado': 'R$210',
-  'Blend Kickboxing - Básico': 'R$170',
-  'Blend Kickboxing - Intermediário': 'R$190',
-  'Blend Kickboxing - Avançado': 'R$210',
   'Luta Livre - Básico': 'R$170',
   'Luta Livre - Intermediário': 'R$190',
   'Luta Livre - Avançado': 'R$210'
@@ -69,9 +63,6 @@ const modules = {
   'Jeet Kune Do - Básico': ['Fundamentos', 'Defesa Pessoal', 'Condicionamento'],
   'Jeet Kune Do - Intermediário': ['Aplicações', 'Combinações', 'Estratégias'],
   'Jeet Kune Do - Avançado': ['Sparring', 'Filosofia', 'Táticas Avançadas'],
-  'Blend Kickboxing - Básico': ['Postura', 'Golpes Básicos', 'Condicionamento'],
-  'Blend Kickboxing - Intermediário': ['Combinações', 'Defesa', 'Táticas'],
-  'Blend Kickboxing - Avançado': ['Golpes Avançados', 'Estratégia', 'Sparring'],
   'Luta Livre - Básico': ['Quedas', 'Controle de Solo', 'Finalizações Básicas'],
   'Luta Livre - Intermediário': ['Passagens de Guarda', 'Raspagens', 'Finalizações Intermediárias'],
   'Luta Livre - Avançado': ['Guarda Avançada', 'Estrangulamentos', 'Competição']


### PR DESCRIPTION
## Summary
- remove Blend Kickboxing course listings from the homepage
- drop Blend Kickboxing options from the registration form

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685175b17b98832197f9db27fac1e8c3