### PR TITLE
Add photo gallery to about page

### DIFF
--- a/sobre.html
+++ b/sobre.html
@@ -24,6 +24,14 @@
     <h2 class="mb-3">Sobre o Instrutor</h2>
     <p>Sou Edmárcio Rodrigues, mestre de artes marciais com mais de três décadas de dedicação e paixão por diversas modalidades de luta. Minha vasta experiência abrange disciplinas como Jiu-Jitsu, Kung Fu, Filipino Martial Arts, Wing Chun, Luta Livre Grappling e métodos de auto defesa. Edmárcio é um dos mais altos níveis na América Latina na arte de Bruce Lee, o Jeet Kune Do, se igualando a americanos e europeus. Isso lhe confere uma perspectiva única e altamente qualificada no ensino de técnicas de combate.</p>
     <p>Ao longo da minha carreira, me destaquei não apenas pela excelência técnica, mas também pela habilidade em transmitir esses conhecimentos de forma acessível e aplicável a todos, desde iniciantes até praticantes avançados.</p>
+    <h3 class="mt-4">Galeria de Fotos</h3>
+    <div class="gallery">
+      <img src="treinamentoonline/Images/WhatsApp Image 2025-06-17 at 11.07.04 (1).jpeg" class="img-fluid" alt="Foto do treinamento 1">
+      <img src="treinamentoonline/Images/WhatsApp Image 2025-06-17 at 11.07.04.jpeg" class="img-fluid" alt="Foto do treinamento 2">
+      <img src="treinamentoonline/Images/WhatsApp Image 2025-06-17 at 11.07.05 (1).jpeg" class="img-fluid" alt="Foto do treinamento 3">
+      <img src="treinamentoonline/Images/WhatsApp Image 2025-06-17 at 11.07.05 (2).jpeg" class="img-fluid" alt="Foto do treinamento 4">
+      <img src="treinamentoonline/Images/WhatsApp Image 2025-06-17 at 11.07.05.jpeg" class="img-fluid" alt="Foto do treinamento 5">
+    </div>
   </main>
   <footer class="text-center py-3 border-top border-warning">
     <p class="mb-0">&copy; 2024 Artes Marciais Online</p>

--- a/style.css
+++ b/style.css
@@ -199,3 +199,18 @@ header nav a.login-btn:hover {
   width: 100%;
   margin-top: 10px;
 }
+
+.gallery {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 15px;
+  margin-top: 1rem;
+}
+
+.gallery img {
+  width: 100%;
+  max-width: 220px;
+  border-radius: 8px;
+  border: 2px solid #ffc107;
+}


### PR DESCRIPTION
## Summary
- add new gallery section with images on `sobre.html`
- style gallery layout in `style.css`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68517b07a9b4832197a4dea7981fdda2