### PR TITLE
Add pdf thumbnail in site header

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <header class="text-center py-3 border-bottom border-warning">
-    <h1 class="display-5 text-warning m-0">Treinamento de Artes Marciais</h1>
+    <h1 class="display-5 text-warning m-0 d-flex align-items-center justify-content-center"><object data="treinamentoonline/Images/DOC-20241231-WA0014..pdf" type="application/pdf" width="50" height="50" class="me-2"></object>Treinamento de Artes Marciais</h1>
     <nav class="mt-2">
       <a href="index.html" class="me-3">Início</a>
       <a href="sobre.html" class="me-3">Sobre</a>

--- a/login.html
+++ b/login.html
@@ -12,7 +12,7 @@
 </head>
 <body class="login-page">
   <header class="text-center py-3 border-bottom border-warning">
-    <h1 class="display-5 text-warning m-0">Treinamento de Artes Marciais</h1>
+    <h1 class="display-5 text-warning m-0 d-flex align-items-center justify-content-center"><object data="treinamentoonline/Images/DOC-20241231-WA0014..pdf" type="application/pdf" width="50" height="50" class="me-2"></object>Treinamento de Artes Marciais</h1>
     <nav class="mt-2">
       <a href="index.html" class="me-3">Início</a>
       <a href="sobre.html">Sobre</a>

--- a/register.html
+++ b/register.html
@@ -12,7 +12,7 @@
 </head>
 <body class="login-page">
   <header class="text-center py-3 border-bottom border-warning">
-    <h1 class="display-5 text-warning m-0">Treinamento de Artes Marciais</h1>
+    <h1 class="display-5 text-warning m-0 d-flex align-items-center justify-content-center"><object data="treinamentoonline/Images/DOC-20241231-WA0014..pdf" type="application/pdf" width="50" height="50" class="me-2"></object>Treinamento de Artes Marciais</h1>
     <nav class="mt-2">
       <a href="index.html" class="me-3">Início</a>
       <a href="sobre.html" class="me-3">Sobre</a>

--- a/sobre.html
+++ b/sobre.html
@@ -12,7 +12,7 @@
 </head>
 <body>
   <header class="text-center py-3 border-bottom border-warning">
-    <h1 class="display-5 text-warning m-0">Treinamento de Artes Marciais</h1>
+    <h1 class="display-5 text-warning m-0 d-flex align-items-center justify-content-center"><object data="treinamentoonline/Images/DOC-20241231-WA0014..pdf" type="application/pdf" width="50" height="50" class="me-2"></object>Treinamento de Artes Marciais</h1>
     <nav class="mt-2">
       <a href="index.html" class="me-3">Início</a>
       <a href="sobre.html" class="me-3">Sobre</a>


### PR DESCRIPTION
## Summary
- show a small pdf preview next to the "Treinamento de Artes Marciais" heading on all HTML pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68517e7401cc8321ba927d0d6f2d6d4e