### PR TITLE
Add banner image before infoproducts

### DIFF
--- a/treinamentoonline/app/page.tsx
+++ b/treinamentoonline/app/page.tsx
@@ -1,10 +1,13 @@
 import { Hero } from "@/components/Hero";
 import { ProductGrid } from "@/components/ProductGrid";
+import Image from "next/image";
+import bannerSrc from "../Images/WhatsApp Image 2025-06-18 at 12.50.03.jpeg";
 
 export default function Page() {
   return (
     <>
       <Hero />
+      <Image src={bannerSrc} alt="Banner" className="mx-auto my-8" />
       <ProductGrid />
     </>
   );


### PR DESCRIPTION
## Summary
- add a banner image to the landing page before listing the infoprodutos

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6853583d0dd883219e8c768ef604b797