### PR TITLE
Add presentation image for Luta Livre products

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,8 +42,9 @@
       <img class="jetkune-img" src="treinamentoonline/Images/WhatsApp Image 2025-06-18 at 12.50.23.jpeg" alt="Jeet Kune Do Avançado" />
       <a href="register.html?curso=Jeet%20Kune%20Do%20-%20Avan%C3%A7ado" class="btn btn-warning cadastro-link">Inscreva-se agora!</a>
     </div>
-    <div class="produto">
-      <h3>Luta Livre - Básico</h3>
+      <img src="treinamentoonline/Images/WhatsApp Image 2025-06-18 at 21.49.59.jpeg" alt="Luta Livre Apresentação" class="img-fluid my-3"/>
+      <div class="produto">
+        <h3>Luta Livre - Básico</h3>
       <img class="jetkune-img" src="treinamentoonline/Images/WhatsApp Image 2025-06-17 at 13.09.04.jpeg" alt="Luta Livre Básico" />
       <a href="register.html?curso=Luta%20Livre%20-%20B%C3%A1sico" class="btn btn-warning cadastro-link">Inscreva-se agora!</a>
     </div>


### PR DESCRIPTION
## Summary
- add presentation image before Luta Livre product listings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68552bf98f648321bb64fa5ef2da2042