### PR TITLE
Add thumbnail to header

### DIFF
--- a/treinamentoonline/components/Navbar.tsx
+++ b/treinamentoonline/components/Navbar.tsx
@@ -1,8 +1,10 @@
 "use client";
 import Link from "next/link";
+import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { LogOut, User } from "lucide-react";
 import { supabaseBrowser } from "@/lib/supabase";
+import thumbSrc from "../Images/WhatsApp Image 2025-06-22 at 08.38.00.jpeg";
 
 export function Navbar() {
   const pathname = usePathname();
@@ -12,9 +14,12 @@ export function Navbar() {
   }
   return (
     <nav className="flex items-center justify-between py-4">
-      <Link href="/" className="text-3xl font-extrabold tracking-widest text-yellow-400">
-        Treinamento<span className="text-red-500">Online</span>
-      </Link>
+      <div className="flex items-center gap-2">
+        <Image src={thumbSrc} alt="Logo" width={40} height={40} className="rounded-full" />
+        <Link href="/" className="text-3xl font-extrabold tracking-widest text-yellow-400">
+          Treinamento<span className="text-red-500">Online</span>
+        </Link>
+      </div>
       <div className="flex gap-4 items-center">
         {pathname !== "/(auth)/login" && (
           <Link href="/(auth)/login" className="hover:underline">


### PR DESCRIPTION
## Summary
- add missing `Image` and thumbnail import to navbar
- display small logo image in header

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6859732a27348321a9c6ddc74686aae9