### PR TITLE
Update sobre page with training info

### DIFF
--- a/sobre.html
+++ b/sobre.html
@@ -24,6 +24,22 @@
     <h2 class="mb-3">Sobre o Instrutor</h2>
     <p>Sou Edmárcio Rodrigues, mestre de artes marciais com mais de três décadas de dedicação e paixão por diversas modalidades de luta. Minha vasta experiência abrange disciplinas como Jiu-Jitsu, Kung Fu, Filipino Martial Arts, Wing Chun, Luta Livre Grappling e métodos de auto defesa. Edmárcio é um dos mais altos níveis na América Latina na arte de Bruce Lee, o Jeet Kune Do, se igualando a americanos e europeus. Isso lhe confere uma perspectiva única e altamente qualificada no ensino de técnicas de combate.</p>
     <p>Ao longo da minha carreira, me destaquei não apenas pela excelência técnica, mas também pela habilidade em transmitir esses conhecimentos de forma acessível e aplicável a todos, desde iniciantes até praticantes avançados.</p>
+<h2 class="mt-4">Treinamento Online</h2>
+<p>Tenha acesso ao treinamento de artes marciais ONLINE mais abrangente sobre JEET KUNE DO &amp; KALI do Brasil!</p>
+<p>Em 2014 eu tive a ideia de organizar o estudo e prática Online sobre Jeet Kune Do e disciplinas associadas. Uma oportunidade única de espalhar as artes que tenho me dedicado há muitos anos e oferecer aos entusiastas do Brasil e América Latina uma visão objetiva e clara sobre essas artes, com ênfase no combate, arte, filosofia e cultura.</p>
+<p>Quero apresentar a vocês uma plataforma onde você terá a oportunidade de progredir em artes marciais de combate e auto defesa como Jeet Kune Do, (Arte conceitual criada por Bruce Lee e desenvolvida por Dan Inosanto) que tem como conteúdo programático o Jun Fan Gung Fu.</p>
+<p>Artes marciais Filipinas Kuntao Kali Silat que engloba diversos sistemas e subsistemas com e sem armas.</p>
+<p>Luta Livre NOGI<br>Sistema de Grappling criado no Brasil com origem no Catch Wrestling.</p>
+<p>A plataforma oferecerá conteúdos básicos, intermediários e avançados, indicamos que ao acessar nossa página, que possa iniciar em nossos conteúdos básicos, até que você possa concluir e passar para o intermediário e assim sucessivamente.</p>
+<p>O treinamento ONLINE é um dedo apontado para a lua, você terá que seguir, descobrir e praticar para ir alcançando os níveis de cada progressão.</p>
+<p>Em cada nível você terá a oportunidade de prestar exame via MEET onde irá demonstrar o que assimilou do conteúdo, o tempo de cada nível vai depender de você se sentir preparado e solicitar seu teste.</p>
+<p>Cada teste, existe um taxa extra de exame, onde cobrirá sua avaliação, e envio de certificado do referido nível de graduação!</p>
+<p>Todas as graduações seguem a versão original idealizada pelos antigos, em Jeet Kune Do, as graduações Jun Fan Gung Fu seguem a padronização desenvolvida por Dan Inosanto e seus instrutores, assim como Kali.</p>
+<p>Na Luta Livre, seguimos o padrão de faixas da primeira federação Internacional de Luta Livre criada no Brasil pelo Mestre Daniel D dane, e seus membros da diretoria.</p>
+<p><strong>ATENÇÃO!</strong> Não haverá teste ou exame para Instrutor nesta plataforma, isso só será possível mediante contato presencial em nossa escola ou que possa solicitar um seminário em sua cidade.</p>
+<p>Caso você deseje entrar para o programa de instrutor você necessitará se filiar aqui neste site no link de filiação preencher formulário.</p>
+<p><a href="https://jeetkunedobrasil.com.br/">https://jeetkunedobrasil.com.br/</a></p>
+<p>Essas diretrizes serviram para as artes que estamos oferecendo aqui na plataforma, como JEET KUNE DO, KALI e LUTA LIVRE.</p>
     <h3 class="mt-4">Galeria de Fotos</h3>
     <div class="gallery">
       <img src="treinamentoonline/Images/WhatsApp Image 2025-06-17 at 11.07.04 (1).jpeg" class="img-fluid" alt="Foto do treinamento 1">


### PR DESCRIPTION
## Summary
- expand `sobre.html` with information about the online Jeet Kune Do, Kali, and Luta Livre training

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685975d13c34832189499c000f02aa1b