### PR TITLE
Add mini video player to about page

### DIFF
--- a/sobre.html
+++ b/sobre.html
@@ -38,6 +38,9 @@
   <p><a href="https://jeetkunedobrasil.com.br/">https://jeetkunedobrasil.com.br/</a></p>
   <p>Essas diretrizes serviram para as artes que estamos oferecendo aqui na plataforma, como JEET KUNE DO, KALI e LUTA LIVRE.</p>
   <p class="mt-3"><a href="https://www.youtube.com/watch?v=_G4Zjv0aNes&t=31s" class="btn btn-warning">Assista ao vídeo de apresentação das artes marciais</a></p>
+  <div class="mini-video">
+    <iframe src="https://www.youtube.com/embed/Bf710TUyvXk" title="Demonstração" allowfullscreen></iframe>
+  </div>
   <h2 class="mb-3">Sobre o Instrutor</h2>
     <p>Sou Edmárcio Rodrigues, mestre de artes marciais com mais de três décadas de dedicação e paixão por diversas modalidades de luta. Minha vasta experiência abrange disciplinas como Jiu-Jitsu, Kung Fu, Filipino Martial Arts, Wing Chun, Luta Livre Grappling e métodos de auto defesa. Edmárcio é um dos mais altos níveis na América Latina na arte de Bruce Lee, o Jeet Kune Do, se igualando a americanos e europeus. Isso lhe confere uma perspectiva única e altamente qualificada no ensino de técnicas de combate.</p>
     <p>Ao longo da minha carreira, me destaquei não apenas pela excelência técnica, mas também pela habilidade em transmitir esses conhecimentos de forma acessível e aplicável a todos, desde iniciantes até praticantes avançados.</p>

--- a/style.css
+++ b/style.css
@@ -130,6 +130,17 @@ header nav a.login-btn:hover {
   border: none;
 }
 
+.mini-video {
+  margin: 15px auto;
+  max-width: 360px;
+}
+
+.mini-video iframe {
+  width: 100%;
+  height: 203px;
+  border: none;
+}
+
 .login-container {
   flex: 1;
   display: flex;


### PR DESCRIPTION
## Summary
- embed a new YouTube video in *sobre.html*
- add `.mini-video` style to display a smaller player

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685b40edbf8483218bdc154cb224085d