### PR TITLE
Add Jeet Kune Do basic level 2 module

### DIFF
--- a/jkd-basico-nivel2.html
+++ b/jkd-basico-nivel2.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Jeet Kune Do - Básico Nível 2</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Noto+Serif+JP:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="text-center py-3 border-bottom border-warning">
+    <h1 class="display-5 text-warning m-0 d-flex align-items-center justify-content-center">Treinamento de Artes Marciais Online</h1>
+    <nav class="mt-2">
+      <a href="index.html" class="me-3">Início</a>
+      <a href="sobre.html" class="me-3">Sobre</a>
+      <a href="register.html" class="cadastro-link">Cadastrar</a>
+    </nav>
+  </header>
+  <main class="container py-4">
+    <h2 class="text-warning fw-bold mb-4">Nível Básico - Nível II - Fase 2</h2>
+    <ol>
+      <li class="mb-3">Trabalho de esquivas e saídas
+        <ol type="A" class="mt-2">
+          <li>Slep/esquerda direita</li>
+          <li>Bob Weave/esquerda/direita</li>
+          <li>Lin Back</li>
+          <li>Shoulder Roll</li>
+          <li>Knee Block 1</li>
+          <li>Knee Block 2</li>
+          <li>Knee Block 3</li>
+          <li>Knee Block 4</li>
+          <li>Saída lateral 1 e 2</li>
+          <li>Bai Jong 4 lados</li>
+        </ol>
+      </li>
+      <li class="mb-3">Trapping/Grappling Jun Fan
+        <ol type="A" class="mt-2">
+          <li>Contra Pak Dar /Pak Ping Choy/Quin Na grappling (Arm Hold em pé)</li>
+          <li>Contra Pak Dar/Pak Ping Choy/Quin Na grappling, Arm Hold levando para o chão</li>
+          <li>Contra Pak Dar/Double Leg</li>
+          <li>Loy Pak Dar/Noy Pak Dar/Guilhotina</li>
+          <li>Loy Pak Dar/Noy Pak Dar/Face Lock</li>
+          <li>Pak Dar/Finger Lock</li>
+          <li>Contra Lop Sao Dar</li>
+          <li>Pak Dar/Lop Sao Dar/Quin Na Arm Bar no cotovelo</li>
+        </ol>
+      </li>
+      <li class="mb-3">Jun Fan Gung Fu/Kickboxing
+        <ol type="A" class="mt-2">
+          <li>Catch Tan Dar/Cross/Hook/Cross/O'Ou Tek</li>
+          <li>Catch Shoulder Stop/Cross/Hook/Cross</li>
+          <li>Catch/Stop Bíceps/Cross/Hook/Cross/Juk Tek</li>
+          <li>Catch Biu Dar 1</li>
+          <li>Catch Biu Dar 2</li>
+        </ol>
+      </li>
+      <li class="mb-3">WOODEN DUMMY Set #1
+        <ol type="A" class="mt-2">
+          <li>Jun Fan Gung Fu Boneco de madeira</li>
+          <li>Jun Fan Gung Fu Ser #2</li>
+        </ol>
+      </li>
+    </ol>
+  </main>
+  <img src="treinamentoonline/Images/Assinatura_1.png" alt="Assinatura" class="img-fluid my-3" />
+  <footer class="text-center py-3 border-top border-warning">
+    <p class="mb-0">&copy; 2025 Artes Marciais Online</p>
+  </footer>
+  <audio id="signup-sound" src="treinamentoonline/Sounds/old-zildjian-gong-quite-natural-34294.mp3" preload="auto"></audio>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      const sound = document.getElementById('signup-sound');
+      document.querySelectorAll('.cadastro-link').forEach(function (link) {
+        link.addEventListener('click', function (e) {
+          if (sound) {
+            e.preventDefault();
+            sound.currentTime = 0;
+            sound.play();
+            const href = this.getAttribute('href');
+            setTimeout(function () {
+              window.location.href = href;
+            }, 300);
+          }
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/register.html
+++ b/register.html
@@ -32,6 +32,7 @@
       <label for="arte" class="form-label">Produto</label>
       <select id="arte" name="arte" class="form-select mb-2" onchange="updatePrice();updateModules();updateInfo();">
         <option value="Jeet Kune Do - Básico">Jeet Kune Do - Básico</option>
+        <option value="Jeet Kune Do - Básico Nível 2">Jeet Kune Do - Básico Nível 2</option>
         <option value="Jeet Kune Do - Intermediário">Jeet Kune Do - Intermediário</option>
         <option value="Jeet Kune Do - Avançado">Jeet Kune Do - Avançado</option>
           <option value="Luta Livre - Básico">Luta Livre - Básico</option>
@@ -57,6 +58,7 @@
 <script>
   const prices = {
     'Jeet Kune Do - Básico': 'R$510',
+    'Jeet Kune Do - Básico Nível 2': 'R$510',
     'Jeet Kune Do - Intermediário': 'R$190',
     'Jeet Kune Do - Avançado': 'R$210',
     'Luta Livre - Básico': 'R$170',
@@ -79,6 +81,38 @@
       '9- Jun Fan Gung Fu/Kickboxing Combinations/Focus Mittis: Jab - Cross, Cross - Hook - Cross, Cross - Upper - Cross, Cross - Body Hook - Cross, Qua Choy - Cross - Hook Cross, Kris - Cross, Lead Punch, Chun Choy',
       "10 - Jun Fan Gung Fu/Kickboxing Combinations, socos e chutes: Jab - Cross - O'Ou Tek (perna da frente), Jab - Cross - O'Ou Tek perna de trás, Cross - Hook - Cross - Jik Tek - O'Ou Tek perna da frente, So Tek perna da frente - Cross - Hook - Cross, O'Ou Tek perna da frente - Cross - Hook Cross"
     ],
+    'Jeet Kune Do - Básico Nível 2': [
+      'Nível II - Fase 2',
+      '1 - Trabalho de esquivas e saídas',
+      'A - Slep/esquerda direita',
+      'B - Bob Weave/esquerda/direita',
+      'C - Lin Back',
+      'D - Shoulder Roll',
+      'E - Knee Block 1',
+      'F - Knee Block 2',
+      'G - Knee Block 3',
+      'H - Knee Block 4',
+      'I - Saída lateral 1 e 2',
+      'J - Bai Jong 4 lados',
+      '2 - Trapping/Grappling Jun Fan',
+      'A - Contra Pak Dar /Pak Ping Choy/Quin Na grappling (Arm Hold em pé).',
+      'B - Contra Pak Dar/Pak Ping Choy/Quin Na grappling, Arm Hold levando para o chão.',
+      'C - Contra Pak Dar/Double Leg',
+      'D - Loy Pak Dar/Noy Pak Dar/ Guilhotina',
+      'E - Loy Pak Dar/Noy Pak Dar/Face Lock',
+      'F - Pak Dar /Finger Lock',
+      'G - Contra Lop Sao Dar',
+      'H - Pak Dar/Lop Sao Dar/Quin Na Arm Bar no cotovelo',
+      '3 - Jun Fan Gung Fu/ Kickboxing',
+      "A - Catch Tan Dar/Cross/Hook/Cross/ O'Ou Tek",
+      'B - Catch Shoulder Stop/ Cross/Hook/Cross',
+      'C - Catch/Stop Bíceps/Cross /Hook/Cross/Juk Tek',
+      'D - Catch Biu Dar 1',
+      'E - Catch Biu Dar 2',
+      '4 - WOODEN DUMMY Set # 1',
+      'A - Jun Fan Gung Fu Boneco de madeira .',
+      'Jun Fan Gung Fu Ser # 2'
+    ],
     'Jeet Kune Do - Intermediário': ['Aplicações', 'Combinações', 'Estratégias'],
     'Jeet Kune Do - Avançado': ['Sparring', 'Filosofia', 'Táticas Avançadas'],
     'Luta Livre - Básico': ['Quedas', 'Controle de Solo', 'Finalizações Básicas'],
@@ -91,6 +125,9 @@
   const infos = {
     'Jeet Kune Do - Básico':
       'Este é o conteúdo básico Nível I Valor : R$ 510,00 <br>Atenção! Taxa de avaliação e certificado Incluso!<br><br>Após conclusão do módulo básico, caso você deseje, solicite sua avaliação online!'
+    ,
+    'Jeet Kune Do - Básico Nível 2':
+      'Conteúdo do Nível Básico II - Fase 2. Após finalizado, você pode solicitar sua avaliação online.'
   };
 
 function updatePrice() {


### PR DESCRIPTION
## Summary
- create page with curriculum for Jeet Kune Do Básico Nível 2
- allow selecting the new module in the registration form
- add price and module list for Jeet Kune Do Básico Nível 2

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685c3899e7b48321a37bc7854b30e007