### PR TITLE
Atualiza nomenclatura do curso JKD nivel 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,14 +39,14 @@
       <a href="register.html?curso=Jeet%20Kune%20Do%20-%20B%C3%A1sico" class="btn btn-warning cadastro-link">Inscreva-se agora!</a>
     </div>
     <div class="produto">
-      <h3>Jeet Kune Do - Básico Nível 2</h3>
-      <img class="jetkune-img" src="treinamentoonline/Images/WhatsApp Image 2025-06-18 at 12.50.23 (1).jpeg" alt="Jeet Kune Do Básico Nível 2" />
-      <a href="register.html?curso=Jeet%20Kune%20Do%20-%20B%C3%A1sico%20N%C3%ADvel%202" class="btn btn-warning cadastro-link">Inscreva-se agora!</a>
-    </div>
-    <div class="produto">
       <h3>Jeet Kune Do - Básico Nível 2 Fase 1</h3>
       <img class="jetkune-img" src="treinamentoonline/Images/WhatsApp Image 2025-06-18 at 12.50.23 (1).jpeg" alt="Jeet Kune Do Básico Nível 2 Fase 1" />
       <a href="register.html?curso=Jeet%20Kune%20Do%20-%20B%C3%A1sico%20N%C3%ADvel%202%20Fase%201" class="btn btn-warning cadastro-link">Inscreva-se agora!</a>
+    </div>
+    <div class="produto">
+      <h3>Jeet Kune Do - Básico Nível 2 Fase 2</h3>
+      <img class="jetkune-img" src="treinamentoonline/Images/WhatsApp Image 2025-06-18 at 12.50.23 (1).jpeg" alt="Jeet Kune Do Básico Nível 2 Fase 2" />
+      <a href="register.html?curso=Jeet%20Kune%20Do%20-%20B%C3%A1sico%20N%C3%ADvel%202%20Fase%202" class="btn btn-warning cadastro-link">Inscreva-se agora!</a>
     </div>
     <div class="produto">
       <h3>Jeet Kune Do - Intermediário</h3>

--- a/jkd-basico-nivel2.html
+++ b/jkd-basico-nivel2.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Jeet Kune Do - Básico Nível 2</title>
+  <title>Jeet Kune Do - Básico Nível 2 Fase 2</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Noto+Serif+JP:wght@400;700&display=swap" rel="stylesheet">

--- a/register.html
+++ b/register.html
@@ -35,7 +35,7 @@
       <label for="arte" class="form-label">Produto</label>
       <select id="arte" name="arte" class="form-select mb-2" onchange="updatePrice();updateModules();updateInfo();">
         <option value="Jeet Kune Do - Básico">Jeet Kune Do - Básico</option>
-        <option value="Jeet Kune Do - Básico Nível 2">Jeet Kune Do - Básico Nível 2</option>
+        <option value="Jeet Kune Do - Básico Nível 2 Fase 2">Jeet Kune Do - Básico Nível 2 Fase 2</option>
         <option value="Jeet Kune Do - Intermediário">Jeet Kune Do - Intermediário</option>
         <option value="Jeet Kune Do - Intermediário Nível 2">Jeet Kune Do - Intermediário Nível 2</option>
         <option value="Jeet Kune Do - Avançado">Jeet Kune Do - Avançado</option>
@@ -62,7 +62,7 @@
 <script>
   const prices = {
     'Jeet Kune Do - Básico': 'R$520',
-    'Jeet Kune Do - Básico Nível 2': 'R$600',
+    'Jeet Kune Do - Básico Nível 2 Fase 2': 'R$600',
     'Jeet Kune Do - Básico Nível 2 Fase 1': 'R$580',
     'Jeet Kune Do - Intermediário': 'R$190',
     'Jeet Kune Do - Intermediário Nível 2': 'R$600',
@@ -87,7 +87,7 @@
       '9- Jun Fan Gung Fu/Kickboxing Combinations/Focus Mittis: Jab - Cross, Cross - Hook - Cross, Cross - Upper - Cross, Cross - Body Hook - Cross, Qua Choy - Cross - Hook Cross, Kris - Cross, Lead Punch, Chun Choy',
       "10 - Jun Fan Gung Fu/Kickboxing Combinations, socos e chutes: Jab - Cross - O'Ou Tek (perna da frente), Jab - Cross - O'Ou Tek perna de trás, Cross - Hook - Cross - Jik Tek - O'Ou Tek perna da frente, So Tek perna da frente - Cross - Hook - Cross, O'Ou Tek perna da frente - Cross - Hook Cross"
     ],
-    'Jeet Kune Do - Básico Nível 2': [
+    'Jeet Kune Do - Básico Nível 2 Fase 2': [
       'Nível II - Fase 2',
       '1 - Trabalho de esquivas e saídas',
       'A - Slep/esquerda direita',
@@ -164,7 +164,7 @@
   const infos = {
     'Jeet Kune Do - Básico':
       'Este é o conteúdo básico Nível I Valor : R$ 520,00 <br>Atenção! Taxa de avaliação e certificado Incluso!<br><br>Após conclusão do módulo básico, caso você deseje, solicite sua avaliação online.',
-    'Jeet Kune Do - Básico Nível 2':
+    'Jeet Kune Do - Básico Nível 2 Fase 2':
       'Conteúdo do Nível Básico II - Fase 2. Após finalizado, você pode solicitar sua avaliação online.',
     'Jeet Kune Do - Básico Nível 2 Fase 1':
       'Conteúdo do Nível Básico II - Fase 1. Após finalizado, você pode solicitar sua avaliação online.'


### PR DESCRIPTION
## Summary
- renomear o curso "Jeet Kune Do - Básico Nível 2" para "Jeet Kune Do - Básico Nível 2 Fase 2"
- ordenar a listagem deixando a Fase 1 acima da Fase 2 no `index.html`
- ajustar opção, preços e descrições em `register.html`
- atualizar título da página `jkd-basico-nivel2.html`

## Testing
- `grep -R "Básico Nível 2" -n | head -n 20`


------
https://chatgpt.com/codex/tasks/task_b_685d510f6c5c832199df01572d266904