### PR TITLE
Replace literal newline markers with line breaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>BUDOKAI SHIN KAKUTOGI \nKARATÊ ALL ROUND FIGHTING</title>
+  <title>BUDOKAI SHIN KAKUTOGI
+  KARATÊ ALL ROUND FIGHTING</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Noto+Serif+JP:wght@400;700&display=swap" rel="stylesheet">
@@ -16,7 +17,8 @@
       <div class="header-brand">
         <h1 class="display-5 text-warning m-0 d-flex align-items-center">
           <img src="treinamentoonline/Images/LOGO-BUDOKAI.png" alt="Logo Budokai" class="brand-logo me-2" />
-          BUDOKAI SHIN KAKUTOGI \nKARATÊ ALL ROUND FIGHTING
+          BUDOKAI SHIN KAKUTOGI <br />
+          KARATÊ ALL ROUND FIGHTING
         </h1>
 
         <nav class="mt-2">


### PR DESCRIPTION
## Summary
- replace literal newline markers in the page title and header with real line breaks
- ensure the main heading displays the second line on a new line for readability

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6931e7b6c4d483219e48c6b7de05a19e)